### PR TITLE
Fix syslog call outside linux environment

### DIFF
--- a/ServMain.cpp
+++ b/ServMain.cpp
@@ -502,11 +502,10 @@ int ServiceMain(int argc, const char* argv[], const SrvParam& SrvPara)
         close(STDOUT_FILENO);
         close(STDERR_FILENO);
 
-
+        syslog(LOG_NOTICE, "%s", string(strSrvName + " gestoppt").c_str());
 #endif
         iRet = Service::GetInstance().Run();
 
-        syslog(LOG_NOTICE, "%s", string(strSrvName + " gestoppt").c_str());
     }
 
     return iRet;


### PR DESCRIPTION
A syslog call was executed in the Windows environment. The "syslog.h" library is not supported in this environment, so I moved it into the linux condition.