### PR TITLE
Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,18 +42,20 @@ endif()
 
 add_library(srvlib STATIC ${targetSrc})
 
-add_executable(ExampleSrv  ExampleSrv.cpp)
-target_link_libraries(ExampleSrv srvlib)
-if (NOT MSVC)
-    target_link_libraries(ExampleSrv pthread)
+if(PROJECT_IS_TOP_LEVEL)
+    add_executable(ExampleSrv  ExampleSrv.cpp)
+    target_link_libraries(ExampleSrv srvlib)
+    if (NOT MSVC)
+        target_link_libraries(ExampleSrv pthread)
+    endif()
+
+    file(READ init.d/examplesrv FILE_CONTENTS)
+    string(REPLACE "~" ${CMAKE_CURRENT_BINARY_DIR} NEW_FILE_CONTENTS ${FILE_CONTENTS})
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/examplesrv ${NEW_FILE_CONTENTS})
+
+    file(READ example.service FILE_CONTENTS)
+    string(REPLACE "~" ${CMAKE_CURRENT_BINARY_DIR} NEW_FILE_CONTENTS ${FILE_CONTENTS})
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/example.service ${NEW_FILE_CONTENTS})
+
+    install(TARGETS srvlib DESTINATION lib)
 endif()
-
-file(READ init.d/examplesrv FILE_CONTENTS)
-string(REPLACE "~" ${CMAKE_CURRENT_BINARY_DIR} NEW_FILE_CONTENTS ${FILE_CONTENTS})
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/examplesrv ${NEW_FILE_CONTENTS})
-
-file(READ example.service FILE_CONTENTS)
-string(REPLACE "~" ${CMAKE_CURRENT_BINARY_DIR} NEW_FILE_CONTENTS ${FILE_CONTENTS})
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/example.service ${NEW_FILE_CONTENTS})
-
-install(TARGETS srvlib DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,18 +29,24 @@ else()
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(targetSrc
-    ${CMAKE_CURRENT_LIST_DIR}/ServMain.cpp
-)
+add_library(srvlib STATIC)
 
+set(targetSrc "${CMAKE_CURRENT_SOURCE_DIR}/ServMain.cpp")
 if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") OR WIN32)
 list(APPEND targetSrc
-    ${CMAKE_CURRENT_LIST_DIR}/SrvCtrl.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/BaseSrv.cpp
+    "${CMAKE_CURRENT_SOURCE_DIR}/BaseSrv.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/BaseSrv.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/SrvCtrl.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/SrvCtrl.h"
 )
 endif()
 
-add_library(srvlib STATIC ${targetSrc})
+target_sources(srvlib
+    PRIVATE ${targetSrc}
+    PUBLIC FILE_SET HEADERS
+    BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}"
+    FILES Service.h
+)
 
 if(PROJECT_IS_TOP_LEVEL)
     add_executable(ExampleSrv  ExampleSrv.cpp)

--- a/ExampleSrv.cpp
+++ b/ExampleSrv.cpp
@@ -23,7 +23,7 @@
 #include <unistd.h>
 #endif
 
-int main(int argc, const char* argv[])
+int main(int argc, char* argv[])
 {
     SrvParam svParam;
 #if defined(_WIN32) || defined(_WIN64)

--- a/ServMain.cpp
+++ b/ServMain.cpp
@@ -147,7 +147,7 @@ DWORD WINAPI RemoteThreadProc(LPVOID/* lpParameter*/) noexcept
 }
 #endif
 
-int ServiceMain(int argc, const char* argv[], const SrvParam& SrvPara)
+int ServiceMain(int argc, char* argv[], const SrvParam& SrvPara)
 {
 #if defined(_WIN32) || defined(_WIN64)
     signal(SIGINT, Service::SignalHandler);

--- a/Service.h
+++ b/Service.h
@@ -16,6 +16,6 @@ typedef struct
     std::function<void()> fnSignalCallBack;
 }SrvParam;
 
-int ServiceMain(int argc, const char* argv[], const SrvParam& SrvPara);
+int ServiceMain(int argc, char* argv[], const SrvParam& SrvPara);
 
 #endif // SERVICE_H


### PR DESCRIPTION
Made some improvements to support using this with my own CMake project:
- Add headers to CMake target
- Add support for using CMake project from other CMake projects via `FetchContent`
- Don't build/generate example stuff or install library if being included as part of a higher-level project
- Fix `main()` signature to be standards-compliant, and change `ServiceMain()` to match